### PR TITLE
[DEV] Message Helper

### DIFF
--- a/mvvm-ios/Podfile
+++ b/mvvm-ios/Podfile
@@ -12,4 +12,5 @@ target 'mvvm-ios' do
   pod 'Unbox', '~> 2.5'
   pod 'Kingfisher', '~> 4.3'
   pod 'SVProgressHUD', '~> 2.2'
+  pod 'SwiftMessages', '~> 4.1'
 end

--- a/mvvm-ios/Podfile.lock
+++ b/mvvm-ios/Podfile.lock
@@ -5,6 +5,7 @@ PODS:
     - RxSwift (~> 4.0)
   - RxSwift (4.0.0)
   - SVProgressHUD (2.2.2)
+  - SwiftMessages (4.1.0)
   - Unbox (2.5.0)
 
 DEPENDENCIES:
@@ -13,6 +14,7 @@ DEPENDENCIES:
   - RxCocoa (~> 4.0)
   - RxSwift (~> 4.0)
   - SVProgressHUD (~> 2.2)
+  - SwiftMessages (~> 4.1)
   - Unbox (~> 2.5)
 
 SPEC CHECKSUMS:
@@ -21,8 +23,9 @@ SPEC CHECKSUMS:
   RxCocoa: d62846ca96495d862fa4c59ea7d87e5031d7340e
   RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334
   SVProgressHUD: 59b2d3dabacbd051576d21d32293ca7228dc18b0
+  SwiftMessages: 1bacc783c8f10bdfdc57c14860cae8a1f1fa6591
   Unbox: 30e437e6151a6de16139375fd4e8dd9a664cfbf7
 
-PODFILE CHECKSUM: ca4bf6322fe4fa58e759f96676e3e1290debffdd
+PODFILE CHECKSUM: 1cc6e4a1877cace0b0b88caf48083f2ea276e464
 
 COCOAPODS: 1.3.1

--- a/mvvm-ios/mvvm-ios.xcodeproj/project.pbxproj
+++ b/mvvm-ios/mvvm-ios.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/SVProgressHUD/SVProgressHUD.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftMessages/SwiftMessages.framework",
 				"${BUILT_PRODUCTS_DIR}/Unbox/Unbox.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -273,6 +274,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SVProgressHUD.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftMessages.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Unbox.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/mvvm-ios/mvvm-ios.xcodeproj/project.pbxproj
+++ b/mvvm-ios/mvvm-ios.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		458BC50D1FC61C5E00395B82 /* GHUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458BC50C1FC61C5E00395B82 /* GHUser.swift */; };
 		458BC5101FC6226900395B82 /* APIClient+Github.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458BC50E1FC6226900395B82 /* APIClient+Github.swift */; };
 		458BC5131FC622C700395B82 /* GithubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458BC5121FC622C700395B82 /* GithubService.swift */; };
+		45C5BAC41FC772B1008F25AB /* MessageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C5BAC31FC772B1008F25AB /* MessageHelper.swift */; };
 		45F085E81FC5DFFC0067478E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F085E71FC5DFFC0067478E /* AppDelegate.swift */; };
 		45F085EA1FC5DFFC0067478E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F085E91FC5DFFC0067478E /* ViewController.swift */; };
 		45F085ED1FC5DFFC0067478E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 45F085EB1FC5DFFC0067478E /* Main.storyboard */; };
@@ -35,6 +36,7 @@
 		458BC50C1FC61C5E00395B82 /* GHUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GHUser.swift; sourceTree = "<group>"; };
 		458BC50E1FC6226900395B82 /* APIClient+Github.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "APIClient+Github.swift"; sourceTree = "<group>"; };
 		458BC5121FC622C700395B82 /* GithubService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubService.swift; sourceTree = "<group>"; };
+		45C5BAC31FC772B1008F25AB /* MessageHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageHelper.swift; sourceTree = "<group>"; };
 		45F085E41FC5DFFC0067478E /* mvvm-ios.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "mvvm-ios.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		45F085E71FC5DFFC0067478E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		45F085E91FC5DFFC0067478E /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -62,6 +64,7 @@
 			isa = PBXGroup;
 			children = (
 				4588B2361FC750C400F1E8A9 /* UIView+Extras.swift */,
+				45C5BAC31FC772B1008F25AB /* MessageHelper.swift */,
 			);
 			path = Extras;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 				458BC5101FC6226900395B82 /* APIClient+Github.swift in Sources */,
 				4588B2371FC750C400F1E8A9 /* UIView+Extras.swift in Sources */,
 				458BC5131FC622C700395B82 /* GithubService.swift in Sources */,
+				45C5BAC41FC772B1008F25AB /* MessageHelper.swift in Sources */,
 				45F085E81FC5DFFC0067478E /* AppDelegate.swift in Sources */,
 				458BC5021FC60E6600395B82 /* NetworkInterceptor.swift in Sources */,
 				458BC50D1FC61C5E00395B82 /* GHUser.swift in Sources */,

--- a/mvvm-ios/mvvm-ios/Extras/MessageHelper.swift
+++ b/mvvm-ios/mvvm-ios/Extras/MessageHelper.swift
@@ -1,0 +1,75 @@
+//
+//  MessageHelper.swift
+//  mvvm-ios
+//
+//  Created by Sergii Frost on 2017-11-23.
+//  Copyright © 2017 Frost Experience AB. All rights reserved.
+//
+
+import UIKit
+import SwiftMessages
+
+enum MessageType {
+    case success
+    case info
+    case warning
+    case error
+    
+    var theme: Theme {
+        switch self {
+        case .success:
+            return Theme.success
+        case .info:
+            return Theme.info
+        case .warning:
+            return Theme.warning
+        case .error:
+            return Theme.error
+        }
+    }
+}
+
+public class MessageHelper {
+    
+    private init() {
+        //avoid public instantiation
+    }
+    
+    class func showMessage(forType type: MessageType, title: String? = nil, message: String? = nil) {
+        
+        var config = SwiftMessages.Config()
+        config.duration = .seconds(seconds: 3)
+        
+        SwiftMessages.show(config: config) {
+            let messageView = generateMessageView(forType: type)
+            
+            if let title = title {
+                messageView.titleLabel?.text = title;
+            } else {
+                messageView.titleLabel?.isHidden = true
+            }
+            if let message = message {
+                messageView.bodyLabel?.text = message
+            } else {
+                messageView.bodyLabel?.isHidden = true
+            }
+            
+            return messageView
+        }
+    }
+    
+    static func showMessage(forError error: Error?) {
+        MessageHelper.showMessage(forType: .error, title: nil, message: error?.localizedDescription)
+    }
+    
+    private class func generateMessageView(forType type: MessageType) -> MessageView {
+        let messageView = MessageView.viewFromNib(layout: .messageView)
+        messageView.configureTheme(type.theme)
+        
+        //Hide iconLabel and button by default
+        messageView.button?.isHidden = true
+        messageView.iconLabel?.isHidden = true
+        
+        return messageView
+    }
+}


### PR DESCRIPTION
Adding `MessageHelper` to show different types of messages to the user:

- success
- info
- warning
- error

`MessageHelper` is using [SwiftMessages](https://github.com/SwiftKickMobile/SwiftMessages) under the hood. 